### PR TITLE
Fix release messages

### DIFF
--- a/cron/daily-message.js
+++ b/cron/daily-message.js
@@ -5,9 +5,9 @@ function createMessage({dateString, waitingFor}) {
     return;
   }
 
-  const date = moment(dateString).add(5, 'days');
+  const date = moment(dateString).add(4, 'days');
   const dayDiff = moment().diff(date, 'days');
-  
+
   if (dayDiff === -11) {
     return `Release week starts next week on ${moment(dateString).format('YYYY-MM-DD')} are we all prepared? :lts:`;
   }
@@ -39,7 +39,7 @@ function createMessage({dateString, waitingFor}) {
 
   if (dayDiff > 0) {
     if (waitingFor.length) {
-      return `We are currently :rotating_light: ${dayDiff + 1} Days Late :rotating_light: with the release!! We are still waiting on ${waitingFor.join(', ')}`;
+      return `We are currently :rotating_light: ${dayDiff} Days Late :rotating_light: with the release!! We are still waiting on ${waitingFor.join(', ')}`;
     }
   }
 }
@@ -62,7 +62,7 @@ module.exports = {
       }));
 
       waitingFor = _.compact(waitingFor);
-      
+
       const message = createMessage({ dateString, waitingFor });
 
       if (!message) {

--- a/test/cron/daily-message.js
+++ b/test/cron/daily-message.js
@@ -4,12 +4,12 @@ const tk = require('timekeeper');
 const dailyMessage = rootRequire('cron/daily-message');
 
 async function assertMessageForDate({
-  today,
+  todayDate,
   releaseDate,
   message,
   released = [],
 }) {
-  const now = new Date(`${today} 12:00`);
+  const now = new Date(`${todayDate} 12:00`);
   tk.freeze(now);
 
   await dailyMessage.job({
@@ -22,7 +22,7 @@ async function assertMessageForDate({
   }, {
     get(key) {
       if (key === 'date') {
-        return new Date(releaseDate);
+        return new Date(`${releaseDate} 12:00`);
       }
 
       const [, product] = key.match(/^(\w+):done/);
@@ -37,7 +37,7 @@ describe('daily-message cron job', function () {
     tk.reset();
   });
 
-  it('should send a message the Friday before release week', async function() {
+  it('should send a message the Monday before release week', async function() {
     await assertMessageForDate({
       todayDate: '2020-07-13',
       releaseDate: '2020-07-20',
@@ -53,7 +53,7 @@ describe('daily-message cron job', function () {
       message: [
         `:tada: It's release week!! :tada: To see who is done and who isn't you can say '!release done' and I'll tell you who still needs to do something!`,
         '',
-        `If you know a team is done you can say '!release done <team>' where team can be blog, framework, data, or cli`
+        `If you know a team is done you can say '!release done <team>' where team can be blog, framework, data, or cli.`
       ].join('\n'),
     });
   });
@@ -91,6 +91,14 @@ describe('daily-message cron job', function () {
       released: ['framework', 'cli', 'blog', 'data'],
     });
   });
+
+  it('should send a message saying were 1 days late 1 days after the end of release week', async function() {
+    await assertMessageForDate({
+      todayDate: '2020-07-25',
+      releaseDate: '2020-07-20',
+      message: `We are currently :rotating_light: 1 Days Late :rotating_light: with the release!! We are still waiting on blog, cli, framework, data`,
+    });
+  })
 
   it('should send a message saying were 2 days late 2 days after the end of release week', async function() {
     await assertMessageForDate({


### PR DESCRIPTION
We were sending a release message that indicated it was the last day of release week on Saturday when it should only say this on Friday.

This addresses that issue and also found that tests were passing with undefined values (variables were misnamed).