### PR TITLE
Fix alert date diffing

### DIFF
--- a/cron/daily-message.js
+++ b/cron/daily-message.js
@@ -6,8 +6,8 @@ function createMessage({dateString, waitingFor}) {
     return;
   }
 
-  const date = moment(dateString).add(4, 'days');
-  const hoursUntilRelease = date.diff(moment(), 'hours');
+  const releaseDate = moment(dateString).add(4, 'days');
+  const hoursUntilRelease = releaseDate.diff(moment(), 'hours');
 
   if (hoursUntilRelease >= 262 && hoursUntilRelease <= 266) {
     return `Release week starts next week on ${moment(dateString).format('YYYY-MM-DD')} are we all prepared? :lts:`;
@@ -40,7 +40,8 @@ function createMessage({dateString, waitingFor}) {
 
   if (hoursUntilRelease < 0) {
     if (waitingFor.length) {
-      return `We are currently :rotating_light: ${Math.round(-1 * hoursUntilRelease / 24)} Days Late :rotating_light: with the release!! We are still waiting on ${waitingFor.join(', ')}`;
+      const daysAfterRelease = Math.round(-1 * hoursUntilRelease / 24);
+      return `We are currently :rotating_light: ${daysAfterRelease} Days Late :rotating_light: with the release!! We are still waiting on ${waitingFor.join(', ')}`;
     }
   }
 }

--- a/cron/daily-message.js
+++ b/cron/daily-message.js
@@ -9,11 +9,11 @@ function createMessage({dateString, waitingFor}) {
   const releaseDate = moment(dateString).add(4, 'days');
   const hoursUntilRelease = releaseDate.diff(moment(), 'hours');
 
-  if (hoursUntilRelease >= 262 && hoursUntilRelease <= 266) {
+  if (isReleaseInXDays(11, hoursUntilRelease)) {
     return `Release week starts next week on ${moment(dateString).format('YYYY-MM-DD')} are we all prepared? :lts:`;
   }
 
-  if (hoursUntilRelease >= 94 && hoursUntilRelease <= 98) {
+  if (isReleaseInXDays(4, hoursUntilRelease)) {
     return [
       `:tada: It's release week!! :tada: To see who is done and who isn't you can say '!release done' and I'll tell you who still needs to do something!`,
       '',
@@ -21,7 +21,7 @@ function createMessage({dateString, waitingFor}) {
     ].join('\n');
   }
 
-  if (hoursUntilRelease >= 46 && hoursUntilRelease <= 50) {
+  if (isReleaseInXDays(2, hoursUntilRelease)) {
     if (waitingFor.length) {
       // eslint-disable-next-line quotes
       return `We're half way through release week! Remember: you can say '!release done' to see who still needs to release!`;
@@ -30,7 +30,7 @@ function createMessage({dateString, waitingFor}) {
     }
   }
 
-  if (hoursUntilRelease >= -2 && hoursUntilRelease <= 2) {
+  if (isReleaseInXDays(0, hoursUntilRelease)) {
     if (waitingFor.length) {
       return `Today is the last day of release week! We're still waiting on ${waitingFor.join(', ')}. Can we release today?`;
     } else {
@@ -44,6 +44,13 @@ function createMessage({dateString, waitingFor}) {
       return `We are currently :rotating_light: ${daysAfterRelease} Days Late :rotating_light: with the release!! We are still waiting on ${waitingFor.join(', ')}`;
     }
   }
+}
+
+function isReleaseInXDays(xDays, hoursUntilRelease) {
+  const hourLowerBound = 24 * xDays - 2;
+  const hourUpperBound = 24 * xDays + 2;
+
+  return (hourLowerBound <= hoursUntilRelease) && (hoursUntilRelease <= hourUpperBound);
 }
 
 module.exports = {

--- a/cron/daily-message.js
+++ b/cron/daily-message.js
@@ -1,5 +1,6 @@
 const moment = require('moment');
 const _ = require('lodash');
+
 function createMessage({dateString, waitingFor}) {
   if (!dateString) {
     return;
@@ -7,13 +8,18 @@ function createMessage({dateString, waitingFor}) {
 
   const date = moment(dateString).add(4, 'days');
 
-  const hourDiff = moment().diff(date, 'hours');
+  const hoursUntilRelease = date.diff(moment(), 'hours');
+  let hoursLate = 0;
 
-  if (hourDiff <= -262 && hourDiff >= -266) {
+  if (hoursUntilRelease < 0) {
+    hoursLate = -1 * hoursUntilRelease;
+  }
+
+  if (hoursUntilRelease >= 262 && hoursUntilRelease <= 266) {
     return `Release week starts next week on ${moment(dateString).format('YYYY-MM-DD')} are we all prepared? :lts:`;
   }
 
-  if (hourDiff <= -94 && hourDiff >= -98) {
+  if (hoursUntilRelease >= 94 && hoursUntilRelease <= 98) {
     return [
       `:tada: It's release week!! :tada: To see who is done and who isn't you can say '!release done' and I'll tell you who still needs to do something!`,
       '',
@@ -21,7 +27,7 @@ function createMessage({dateString, waitingFor}) {
     ].join('\n');
   }
 
-  if (hourDiff <= -46 && hourDiff >= -50) {
+  if (hoursUntilRelease >= 46 && hoursUntilRelease <= 50) {
     if (waitingFor.length) {
       // eslint-disable-next-line quotes
       return `We're half way through release week! Remember: you can say '!release done' to see who still needs to release!`;
@@ -30,7 +36,7 @@ function createMessage({dateString, waitingFor}) {
     }
   }
 
-  if (hourDiff <= 2 && hourDiff >= -2) {
+  if (hoursLate <= 2 && hoursUntilRelease <= 2) {
     if (waitingFor.length) {
       return `Today is the last day of release week! We're still waiting on ${waitingFor.join(', ')}. Can we release today?`;
     } else {
@@ -38,9 +44,9 @@ function createMessage({dateString, waitingFor}) {
     }
   }
 
-  if (hourDiff > 0) {
+  if (hoursLate > 0) {
     if (waitingFor.length) {
-      return `We are currently :rotating_light: ${hourDiff / 24} Days Late :rotating_light: with the release!! We are still waiting on ${waitingFor.join(', ')}`;
+      return `We are currently :rotating_light: ${Math.round(hoursLate / 24)} Days Late :rotating_light: with the release!! We are still waiting on ${waitingFor.join(', ')}`;
     }
   }
 }

--- a/cron/daily-message.js
+++ b/cron/daily-message.js
@@ -44,7 +44,7 @@ function createMessage({dateString, waitingFor}) {
     }
   }
 
-  if (hoursLate > 0) {
+  if (hoursLate > 2) {
     if (waitingFor.length) {
       return `We are currently :rotating_light: ${Math.round(hoursLate / 24)} Days Late :rotating_light: with the release!! We are still waiting on ${waitingFor.join(', ')}`;
     }

--- a/cron/daily-message.js
+++ b/cron/daily-message.js
@@ -6,13 +6,14 @@ function createMessage({dateString, waitingFor}) {
   }
 
   const date = moment(dateString).add(4, 'days');
-  const dayDiff = moment().diff(date, 'days');
 
-  if (dayDiff === -11) {
+  const hourDiff = moment().diff(date, 'hours');
+
+  if (hourDiff <= -262 && hourDiff >= -266) {
     return `Release week starts next week on ${moment(dateString).format('YYYY-MM-DD')} are we all prepared? :lts:`;
   }
 
-  if (dayDiff === -4) {
+  if (hourDiff <= -94 && hourDiff >= -98) {
     return [
       `:tada: It's release week!! :tada: To see who is done and who isn't you can say '!release done' and I'll tell you who still needs to do something!`,
       '',
@@ -20,7 +21,7 @@ function createMessage({dateString, waitingFor}) {
     ].join('\n');
   }
 
-  if (dayDiff === -2) {
+  if (hourDiff <= -46 && hourDiff >= -50) {
     if (waitingFor.length) {
       // eslint-disable-next-line quotes
       return `We're half way through release week! Remember: you can say '!release done' to see who still needs to release!`;
@@ -29,7 +30,7 @@ function createMessage({dateString, waitingFor}) {
     }
   }
 
-  if (dayDiff === 0) {
+  if (hourDiff <= 2 && hourDiff >= -2) {
     if (waitingFor.length) {
       return `Today is the last day of release week! We're still waiting on ${waitingFor.join(', ')}. Can we release today?`;
     } else {
@@ -37,9 +38,9 @@ function createMessage({dateString, waitingFor}) {
     }
   }
 
-  if (dayDiff > 0) {
+  if (hourDiff > 0) {
     if (waitingFor.length) {
-      return `We are currently :rotating_light: ${dayDiff} Days Late :rotating_light: with the release!! We are still waiting on ${waitingFor.join(', ')}`;
+      return `We are currently :rotating_light: ${hourDiff / 24} Days Late :rotating_light: with the release!! We are still waiting on ${waitingFor.join(', ')}`;
     }
   }
 }
@@ -63,10 +64,14 @@ module.exports = {
 
       waitingFor = _.compact(waitingFor);
 
-      const message = createMessage({ dateString, waitingFor });
+      let message = createMessage({ dateString, waitingFor });
 
       if (!message) {
-        return;
+        if (process.env.NODE_ENV === 'test' && waitingFor.length) {
+          message = ('No message!');
+        } else {
+          return;
+        }
       }
 
       channels.forEach((channel) => {

--- a/cron/daily-message.js
+++ b/cron/daily-message.js
@@ -7,13 +7,7 @@ function createMessage({dateString, waitingFor}) {
   }
 
   const date = moment(dateString).add(4, 'days');
-
   const hoursUntilRelease = date.diff(moment(), 'hours');
-  let hoursLate = 0;
-
-  if (hoursUntilRelease < 0) {
-    hoursLate = -1 * hoursUntilRelease;
-  }
 
   if (hoursUntilRelease >= 262 && hoursUntilRelease <= 266) {
     return `Release week starts next week on ${moment(dateString).format('YYYY-MM-DD')} are we all prepared? :lts:`;
@@ -36,7 +30,7 @@ function createMessage({dateString, waitingFor}) {
     }
   }
 
-  if (hoursLate <= 2 && hoursUntilRelease <= 2) {
+  if (hoursUntilRelease >= -2 && hoursUntilRelease <= 2) {
     if (waitingFor.length) {
       return `Today is the last day of release week! We're still waiting on ${waitingFor.join(', ')}. Can we release today?`;
     } else {
@@ -44,12 +38,13 @@ function createMessage({dateString, waitingFor}) {
     }
   }
 
-  if (hoursLate > 2) {
+  if (hoursUntilRelease < 0) {
     if (waitingFor.length) {
-      return `We are currently :rotating_light: ${Math.round(hoursLate / 24)} Days Late :rotating_light: with the release!! We are still waiting on ${waitingFor.join(', ')}`;
+      return `We are currently :rotating_light: ${Math.round(-1 * hoursUntilRelease / 24)} Days Late :rotating_light: with the release!! We are still waiting on ${waitingFor.join(', ')}`;
     }
   }
 }
+
 module.exports = {
   cron: '00 10 * * *', // once a day at 9:30 UTC
   job(client, keyv) {

--- a/test/cron/daily-message.js
+++ b/test/cron/daily-message.js
@@ -9,7 +9,7 @@ async function assertMessageForDate({
   message,
   released = [],
 }) {
-  const now = new Date(`${todayDate} 12:00`);
+  const now = new Date(`${todayDate} 10:01 GMT+00:00`);
   tk.freeze(now);
 
   await dailyMessage.job({
@@ -22,7 +22,7 @@ async function assertMessageForDate({
   }, {
     get(key) {
       if (key === 'date') {
-        return new Date(`${releaseDate} 12:00`);
+        return new Date(`${releaseDate} 10:00 GMT+00:00`);
       }
 
       const [, product] = key.match(/^(\w+):done/);
@@ -117,7 +117,7 @@ describe('daily-message cron job', function () {
   });
 
   it('should not send a message if we are late and all bits are released', async function() {
-    const now = new Date(`2020-07-27 12:00`);
+    const now = new Date(`2020-07-27 10:01 GMT+00:00`);
     tk.freeze(now);
 
     const released = ['framework', 'cli', 'blog', 'data'];
@@ -132,7 +132,7 @@ describe('daily-message cron job', function () {
     }, {
       get(key) {
         if (key === 'date') {
-          return new Date('2020-07-20');
+          return new Date('2020-07-20 10:00 GMT+00:00');
         }
 
         const [, product] = key.match(/^(\w+):done/);

--- a/test/cron/daily-message.js
+++ b/test/cron/daily-message.js
@@ -98,7 +98,7 @@ describe('daily-message cron job', function () {
       releaseDate: '2020-07-20',
       message: `We are currently :rotating_light: 1 Days Late :rotating_light: with the release!! We are still waiting on blog, cli, framework, data`,
     });
-  })
+  });
 
   it('should send a message saying were 2 days late 2 days after the end of release week', async function() {
     await assertMessageForDate({


### PR DESCRIPTION
- we were running an alert the day before the last day in the release week
- this was happening because alerts are driven by date diffing with a precision of the diff in days. therefore if the cron job was run on 12/31/20 10:01 am UTC and the last day in release week is 01/01/21 10:00 am UTC (i.e. technically less than a day), moment's diff method will return 0 if the precision is set to days, firing the alert 1 day early in addition to the last day in release week.
- this moves to an hourly precision and provides a 4 hour window in which the cron job can be running around the release date at 10 am UTC. providing this window allows not only for the job to take some time to run, but also shifts in daylight savings time which do affect running the tests locally (depending on what time zone one is in)
- we also were not causing the test assertions to fail, but rather skipping running the assertion altogether if conditions were not met. the tests will now fail if conditions are not met.