### PR TITLE
get Discord client id from env

### DIFF
--- a/settings/index.js
+++ b/settings/index.js
@@ -15,6 +15,7 @@ if (nconf.get('nconf:file')) {
 // common options
 nconf.defaults({
   token: process.env.DISCORD_TOKEN,
+  clientId: process.env.DISCORD_CLIENT_ID,
 });
 
 module.exports = nconf.get();

--- a/settings/production.json
+++ b/settings/production.json
@@ -1,6 +1,5 @@
 {
   "nconf": {
     "file": "./settings/secure.json"
-  },
-  "clientId": "519243998380949505"
+  }
 }


### PR DESCRIPTION
This will allow our staging test app to use the staging client ID and not try to use production 🙃 